### PR TITLE
Progression gating

### DIFF
--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -271,6 +271,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   moveMediumBox: {fileID: 75807144}
+  button_1_1: {fileID: 0}
+  button_1_2: {fileID: 0}
+  button_1_3: {fileID: 0}
+  button_2_1: {fileID: 0}
+  button_2_2: {fileID: 0}
+  button_2_3: {fileID: 0}
+  button_3_1: {fileID: 0}
+  button_3_2: {fileID: 0}
+  button_3_3: {fileID: 0}
 --- !u!1 &110692037
 GameObject:
   m_ObjectHideFlags: 0
@@ -964,6 +973,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   moveMediumBox: {fileID: 0}
+  button_1_1: {fileID: 0}
+  button_1_2: {fileID: 0}
+  button_1_3: {fileID: 0}
+  button_2_1: {fileID: 0}
+  button_2_2: {fileID: 0}
+  button_2_3: {fileID: 0}
+  button_3_1: {fileID: 0}
+  button_3_2: {fileID: 0}
+  button_3_3: {fileID: 0}
 --- !u!1 &423626076
 GameObject:
   m_ObjectHideFlags: 0
@@ -2241,6 +2259,7 @@ RectTransform:
   - {fileID: 1104077118}
   - {fileID: 1328897741}
   - {fileID: 1991247590}
+  - {fileID: 2037447729}
   m_Father: {fileID: 2059231926}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -5091,6 +5110,64 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2012906602}
   m_CullTransparentMesh: 1
+--- !u!1 &2037447728
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2037447729}
+  - component: {fileID: 2037447730}
+  m_Layer: 5
+  m_Name: Menu Controller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2037447729
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2037447728}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1092299917}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2037447730
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2037447728}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dea9537a85ae33f4093f647afbe7e328, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveMediumBox: {fileID: 0}
+  button_1_1: {fileID: 886653341}
+  button_1_2: {fileID: 522203657}
+  button_1_3: {fileID: 1658856396}
+  button_2_1: {fileID: 1440607768}
+  button_2_2: {fileID: 2012906604}
+  button_2_3: {fileID: 392728558}
+  button_3_1: {fileID: 835097790}
+  button_3_2: {fileID: 1359384849}
+  button_3_3: {fileID: 475737005}
 --- !u!1 &2042280256
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -134,7 +134,6 @@ GameObject:
   - component: {fileID: 75807143}
   - component: {fileID: 75807145}
   - component: {fileID: 75807144}
-  - component: {fileID: 75807146}
   m_Layer: 5
   m_Name: Normal Text
   m_TagString: Untagged
@@ -208,8 +207,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 75
-  m_fontSizeBase: 75
+  m_fontSize: 65
+  m_fontSizeBase: 65
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -258,28 +257,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 75807142}
   m_CullTransparentMesh: 1
---- !u!114 &75807146
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 75807142}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dea9537a85ae33f4093f647afbe7e328, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  moveMediumBox: {fileID: 75807144}
-  button_1_1: {fileID: 0}
-  button_1_2: {fileID: 0}
-  button_1_3: {fileID: 0}
-  button_2_1: {fileID: 0}
-  button_2_2: {fileID: 0}
-  button_2_3: {fileID: 0}
-  button_3_1: {fileID: 0}
-  button_3_2: {fileID: 0}
-  button_3_3: {fileID: 0}
 --- !u!1 &110692037
 GameObject:
   m_ObjectHideFlags: 0
@@ -364,8 +341,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 75
-  m_fontSizeBase: 75
+  m_fontSize: 65
+  m_fontSizeBase: 65
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -929,14 +906,13 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 415640296}
-  - component: {fileID: 415640297}
   m_Layer: 5
   m_Name: MainMenu
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &415640296
 RectTransform:
   m_ObjectHideFlags: 0
@@ -960,28 +936,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: -222}
   m_SizeDelta: {x: 733.3856, y: 621.0149}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &415640297
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 415640295}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dea9537a85ae33f4093f647afbe7e328, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  moveMediumBox: {fileID: 0}
-  button_1_1: {fileID: 0}
-  button_1_2: {fileID: 0}
-  button_1_3: {fileID: 0}
-  button_2_1: {fileID: 0}
-  button_2_2: {fileID: 0}
-  button_2_3: {fileID: 0}
-  button_3_1: {fileID: 0}
-  button_3_2: {fileID: 0}
-  button_3_3: {fileID: 0}
 --- !u!1 &423626076
 GameObject:
   m_ObjectHideFlags: 0
@@ -1065,7 +1019,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 415640297}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: MainMenu, Assembly-CSharp
         m_MethodName: QuitGame
         m_Mode: 1
@@ -1658,8 +1612,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 75
-  m_fontSizeBase: 75
+  m_fontSize: 65
+  m_fontSizeBase: 65
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -2241,7 +2195,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1092299917
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2259,7 +2213,6 @@ RectTransform:
   - {fileID: 1104077118}
   - {fileID: 1328897741}
   - {fileID: 1991247590}
-  - {fileID: 2037447729}
   m_Father: {fileID: 2059231926}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -2982,8 +2935,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 75
-  m_fontSizeBase: 75
+  m_fontSize: 65
+  m_fontSizeBase: 65
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -3116,8 +3069,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 75
-  m_fontSizeBase: 75
+  m_fontSize: 65
+  m_fontSizeBase: 65
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -3396,8 +3349,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 75
-  m_fontSizeBase: 75
+  m_fontSize: 65
+  m_fontSizeBase: 65
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -3664,8 +3617,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 75
-  m_fontSizeBase: 75
+  m_fontSize: 65
+  m_fontSizeBase: 65
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -3797,7 +3750,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 415640297}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: MainMenu, Assembly-CSharp
         m_MethodName: OpenSettings
         m_Mode: 1
@@ -3931,8 +3884,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 75
-  m_fontSizeBase: 75
+  m_fontSize: 65
+  m_fontSizeBase: 65
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -4770,8 +4723,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 75
-  m_fontSizeBase: 75
+  m_fontSize: 65
+  m_fontSizeBase: 65
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -5134,16 +5087,16 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2037447728}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1092299917}
+  m_Father: {fileID: 2059231926}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 7.9000244, y: -31.299988}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2037447730
@@ -5158,7 +5111,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dea9537a85ae33f4093f647afbe7e328, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  moveMediumBox: {fileID: 0}
   button_1_1: {fileID: 886653341}
   button_1_2: {fileID: 522203657}
   button_1_3: {fileID: 1658856396}
@@ -5396,6 +5348,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 2037447729}
   - {fileID: 415640296}
   - {fileID: 1092299917}
   m_Father: {fileID: 0}

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -134,6 +134,7 @@ GameObject:
   - component: {fileID: 75807143}
   - component: {fileID: 75807145}
   - component: {fileID: 75807144}
+  - component: {fileID: 75807146}
   m_Layer: 5
   m_Name: Normal Text
   m_TagString: Untagged
@@ -257,6 +258,19 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 75807142}
   m_CullTransparentMesh: 1
+--- !u!114 &75807146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 75807142}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dea9537a85ae33f4093f647afbe7e328, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveMediumBox: {fileID: 75807144}
 --- !u!1 &110692037
 GameObject:
   m_ObjectHideFlags: 0
@@ -949,6 +963,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dea9537a85ae33f4093f647afbe7e328, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  moveMediumBox: {fileID: 0}
 --- !u!1 &423626076
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/MainMenu.cs
+++ b/Assets/Scripts/MainMenu.cs
@@ -72,6 +72,8 @@ public class MainMenu : MonoBehaviour
         // which stages are unlocked.
 
         // This could be a clever single efficient string, but this way is dummy proof?
+        // When a level is completed successfully, we'll simply use PlayerPrefs to 
+        // save that completion record to local data.
         int prog_movement_easy = PlayerPrefs.GetInt("prog_movement_easy", 0);
         int prog_movement_medium = PlayerPrefs.GetInt("prog_movement_medium", 0);
         int prog_movement_hard = PlayerPrefs.GetInt("prog_movement_hard", 0);

--- a/Assets/Scripts/MainMenu.cs
+++ b/Assets/Scripts/MainMenu.cs
@@ -2,16 +2,20 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using TMPro;
 
 public class MainMenu : MonoBehaviour
 {
     private static int DEFAULT_RES_WIDTH = 1920;
     private static int DEFAULT_RES_HEIGHT = 1080;
 
+    public TextMeshProUGUI moveMediumBox;
+
     private void Start()
     {
         // Load any settings that were saved from previous sessions
         LoadSettings();
+        LoadProgression();
     }
     public void PlayGame ()
     {
@@ -58,5 +62,33 @@ public class MainMenu : MonoBehaviour
         // 3. Language
         string languageIndexPref = PlayerPrefs.GetString("SelectedLanguage");
         // TODO change the language
+    }
+
+    private void LoadProgression()
+    {
+        // Load progression from PlayerPrefs
+        // Progression includes info on which stages
+        // the player has already beaten. It determines
+        // which stages are unlocked.
+
+        // This could be a clever single efficient string, but this way is dummy proof?
+        int prog_movement_easy = PlayerPrefs.GetInt("prog_movement_easy", 0);
+        int prog_movement_medium = PlayerPrefs.GetInt("prog_movement_medium", 0);
+        int prog_movement_hard = PlayerPrefs.GetInt("prog_movement_hard", 0);
+        int prog_health_easy = PlayerPrefs.GetInt("prog_health_easy", 0);
+        int prog_health_medium = PlayerPrefs.GetInt("prog_health_medium", 0);
+        int prog_health_hard = PlayerPrefs.GetInt("prog_health_hard", 0);
+        int prog_damage_easy = PlayerPrefs.GetInt("prog_damage_easy", 0);
+        int prog_damage_medium = PlayerPrefs.GetInt("prog_damage_medium", 0);
+        int prog_damage_hard = PlayerPrefs.GetInt("prog_damage_hard", 0);
+        
+
+        // quick proof of concept
+        if (prog_movement_easy == 0)
+        {
+            Color grayColor = new Color(0.5f, 0.5f, 0.5f, 1.0f);
+            moveMediumBox.color = grayColor;
+            moveMediumBox.text = "LOCKED";
+        }
     }
 }

--- a/Assets/Scripts/MainMenu.cs
+++ b/Assets/Scripts/MainMenu.cs
@@ -10,7 +10,6 @@ public class MainMenu : MonoBehaviour
     private static int DEFAULT_RES_WIDTH = 1920;
     private static int DEFAULT_RES_HEIGHT = 1080;
 
-    public TextMeshProUGUI moveMediumBox;
     public Button button_1_1, button_1_2, button_1_3, button_2_1, button_2_2, button_2_3, button_3_1, button_3_2, button_3_3;
 
     private void Start()
@@ -76,18 +75,19 @@ public class MainMenu : MonoBehaviour
         // This could be a clever single efficient string, but this way is dummy proof?
         // When a level is completed successfully, we'll simply use PlayerPrefs to 
         // save that completion record to local data.
-        int prog_1_1 = PlayerPrefs.GetInt("prog_1_1", 0);
-        int prog_1_2 = PlayerPrefs.GetInt("prog_1_2", 0);
-        int prog_1_3 = PlayerPrefs.GetInt("prog_1_3", 0);
-        int prog_2_1 = PlayerPrefs.GetInt("prog_2_1", 0);
-        int prog_2_2 = PlayerPrefs.GetInt("prog_2_2", 0);
-        int prog_2_3 = PlayerPrefs.GetInt("prog_2_3", 0);
-        int prog_3_1 = PlayerPrefs.GetInt("prog_3_1", 0);
-        int prog_3_2 = PlayerPrefs.GetInt("prog_3_2", 0);
-        int prog_3_3 = PlayerPrefs.GetInt("prog_3_3", 0);
+        int prog_1_1 = PlayerPrefs.GetInt("progression_1_1", 0);
+        int prog_1_2 = PlayerPrefs.GetInt("progression_1_2", 0);
+        int prog_1_3 = PlayerPrefs.GetInt("progression_1_3", 0);
+        int prog_2_1 = PlayerPrefs.GetInt("progression_2_1", 0);
+        int prog_2_2 = PlayerPrefs.GetInt("progression_2_2", 0);
+        int prog_2_3 = PlayerPrefs.GetInt("progression_2_3", 0);
+        int prog_3_1 = PlayerPrefs.GetInt("progression_3_1", 0);
+        int prog_3_2 = PlayerPrefs.GetInt("progression_3_2", 0);
+        int prog_3_3 = PlayerPrefs.GetInt("progression_3_3", 0);
         
 
         /* quick proof of concept
+        public TextMeshProUGUI moveMediumBox;
         Color grayColor = new Color(0.5f, 0.5f, 0.5f, 1.0f);
         if (prog_1_2 == 0)
         {
@@ -106,7 +106,6 @@ public class MainMenu : MonoBehaviour
         if (prog_2_3  == 0) deactivateButton(button_3_1);
         if (prog_3_1  == 0) deactivateButton(button_3_2);
         if (prog_3_2  == 0) deactivateButton(button_3_3);
-         
     }
 
     private void deactivateButton(Button button)

--- a/Assets/Scripts/MainMenu.cs
+++ b/Assets/Scripts/MainMenu.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 using TMPro;
 
@@ -10,6 +11,7 @@ public class MainMenu : MonoBehaviour
     private static int DEFAULT_RES_HEIGHT = 1080;
 
     public TextMeshProUGUI moveMediumBox;
+    public Button button_1_1, button_1_2, button_1_3, button_2_1, button_2_2, button_2_3, button_3_1, button_3_2, button_3_3;
 
     private void Start()
     {
@@ -74,23 +76,44 @@ public class MainMenu : MonoBehaviour
         // This could be a clever single efficient string, but this way is dummy proof?
         // When a level is completed successfully, we'll simply use PlayerPrefs to 
         // save that completion record to local data.
-        int prog_movement_easy = PlayerPrefs.GetInt("prog_movement_easy", 0);
-        int prog_movement_medium = PlayerPrefs.GetInt("prog_movement_medium", 0);
-        int prog_movement_hard = PlayerPrefs.GetInt("prog_movement_hard", 0);
-        int prog_health_easy = PlayerPrefs.GetInt("prog_health_easy", 0);
-        int prog_health_medium = PlayerPrefs.GetInt("prog_health_medium", 0);
-        int prog_health_hard = PlayerPrefs.GetInt("prog_health_hard", 0);
-        int prog_damage_easy = PlayerPrefs.GetInt("prog_damage_easy", 0);
-        int prog_damage_medium = PlayerPrefs.GetInt("prog_damage_medium", 0);
-        int prog_damage_hard = PlayerPrefs.GetInt("prog_damage_hard", 0);
+        int prog_1_1 = PlayerPrefs.GetInt("prog_1_1", 0);
+        int prog_1_2 = PlayerPrefs.GetInt("prog_1_2", 0);
+        int prog_1_3 = PlayerPrefs.GetInt("prog_1_3", 0);
+        int prog_2_1 = PlayerPrefs.GetInt("prog_2_1", 0);
+        int prog_2_2 = PlayerPrefs.GetInt("prog_2_2", 0);
+        int prog_2_3 = PlayerPrefs.GetInt("prog_2_3", 0);
+        int prog_3_1 = PlayerPrefs.GetInt("prog_3_1", 0);
+        int prog_3_2 = PlayerPrefs.GetInt("prog_3_2", 0);
+        int prog_3_3 = PlayerPrefs.GetInt("prog_3_3", 0);
         
 
-        // quick proof of concept
-        if (prog_movement_easy == 0)
+        /* quick proof of concept
+        Color grayColor = new Color(0.5f, 0.5f, 0.5f, 1.0f);
+        if (prog_1_2 == 0)
         {
-            Color grayColor = new Color(0.5f, 0.5f, 0.5f, 1.0f);
             moveMediumBox.color = grayColor;
             moveMediumBox.text = "LOCKED";
         }
+        */
+
+        // This is the dumbest possible way to do this lol
+        if (prog_1_1  == 0) deactivateButton(button_1_2);
+        if (prog_1_2  == 0) deactivateButton(button_1_3);
+        if (prog_1_3  == 0) deactivateButton(button_2_1);
+        if (prog_1_1  == 0) deactivateButton(button_1_2);
+        if (prog_2_1  == 0) deactivateButton(button_2_2);
+        if (prog_2_2  == 0) deactivateButton(button_2_3);
+        if (prog_2_3  == 0) deactivateButton(button_3_1);
+        if (prog_3_1  == 0) deactivateButton(button_3_2);
+        if (prog_3_2  == 0) deactivateButton(button_3_3);
+         
+    }
+
+    private void deactivateButton(Button button)
+    {
+        TextMeshProUGUI buttonText = button.GetComponentInChildren<TextMeshProUGUI>();
+        buttonText.color = Color.grey;
+        buttonText.text = "LOCKED"; 
+        
     }
 }


### PR DESCRIPTION
When the menu loads, the player's progression for each level is loaded from PlayerPrefs. Each level's key in PlayerPrefs is hardcoded.

For each level that has not been completed already, the appropriate levels will be made unavailable in the menu by changing the text to "LOCKED" and the color to grey.

For each level that a player has completed, a value will need to be saved in PlayerPrefs with the title form eg. `progression_1_1` for level 1-1 (Movement-Easy), `progression_2_3` for level 2-3 (Health-Hard) etc. 